### PR TITLE
Fix basic authentication

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -110,9 +110,9 @@ setAccess() {
 }
 
 setAuth() {
-    if [ -n "$BASIC_AUTH_USER"  ] && [ -n "$BASIC_AUTH_PASSWORD" ]; then
+    if [ -n "${BASIC_AUTH_USER}"  ] && [ -n "${BASIC_AUTH_PASSWORD}" ]; then
         screenOut "Setting up basic auth credentials."
-        sed -i -e"s/#BasicAuth user password/BasicAuth $BASIC_AUTH_USER $BASIC_AUTH_PASSWORD/" $PROXY_CONF
+        sed -i -e"s/#BasicAuth user password/BasicAuth ${BASIC_AUTH_USER} ${BASIC_AUTH_PASSWORD}/" $PROXY_CONF
     fi
 }
 


### PR DESCRIPTION
I found that even when I set `BASIC_AUTH_USER` and `BASIC_AUTH_PASSWORD` variables the proxy still works without authentication. 

Turns out the check for these variables wasn't working, so I changed it a bit and rebuilt the image locally. It worked.